### PR TITLE
fix(crunchyrollVideoPlayer2.css): add 'cursor: pointer' to class .ic_buttons to show expected cursor to the user when hovering over the buttons

### DIFF
--- a/content/css/crunchyrollVideoPlayer2.css
+++ b/content/css/crunchyrollVideoPlayer2.css
@@ -58,6 +58,7 @@ html[ic_runnerThumbnail='blur'] #vilosControlsContainer .css-1dbjc4n.r-kemksi.r-
   background-size: 50%;
   background-repeat: no-repeat;
   background-position: center;
+  cursor: pointer;
 }
 
 .ic_buttons:hover {


### PR DESCRIPTION
Basically, now a hand is shown to the user when they hover over the buttons to emphasize that an action can be done. It's the same behavior shown by the other buttons in the CR player.

