### PR TITLE
feat(website): add anime list integration options

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -20,6 +20,9 @@
   "addSpeedUpShortcut": {
     "message": "Add speed up shortcut"
   },
+  "animeListLinks": {
+    "message": "Anime List Links"
+  },
   "autoSkip": {
     "message": "Auto skip"
   },
@@ -84,6 +87,9 @@
   "disableNumpad": {
     "message": "Disable NumPad"
   },
+  "doNotShow": {
+    "message": "Do not show"
+  },
   "editFastBackwardShortcut": {
     "message": "Edit fast backward shortcut"
   },
@@ -137,6 +143,9 @@
   },
   "hideUi": {
     "message": "Hide UI"
+  },
+  "integrations": {
+    "message": "Integrations"
   },
   "markAllNext": {
     "message": "Mark all next"
@@ -203,6 +212,15 @@
   },
   "show": {
     "message": "Show"
+  },
+  "showOnSeries": {
+    "message": "Series page"
+  },
+  "showOnWatch": {
+    "message": "Watch page"
+  },
+  "showOnSeriesAndWatch": {
+    "message": "Series and watch page"
   },
   "skip": {
     "message": "Skip"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -20,6 +20,9 @@
   "addSpeedUpShortcut": {
     "message": "Agregar atajo de aceleración"
   },
+  "animeListLinks": {
+    "message": "Listas de anime enlace"
+  },
   "autoSkip": {
     "message": "Omisión automático"
   },
@@ -84,6 +87,9 @@
   "disableNumpad": {
     "message": "Desactivar NumPad"
   },
+  "doNotShow": {
+    "message": "No mostrar"
+  },
   "editFastBackwardShortcut": {
     "message": "Editar retroceso atajo"
   },
@@ -137,6 +143,9 @@
   },
   "hideUi": {
     "message": "Esconder UI"
+  },
+  "integrations": {
+    "message": "Integraciones"
   },
   "markAllNext": {
     "message": "Marcar todos los siguientes"
@@ -203,6 +212,15 @@
   },
   "show": {
     "message": "Mostrar"
+  },
+  "showOnSeries": {
+    "message": "Serie página"
+  },
+  "showOnWatch": {
+    "message": "Mostrar página"
+  },
+  "showOnSeriesAndWatch": {
+    "message": "Página de series y relojes"
   },
   "skip": {
     "message": "Saltar"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -20,6 +20,9 @@
   "addSpeedUpShortcut": {
     "message": "Ajouter un raccourci d'accélération"
   },
+  "animeListLinks": {
+    "message": "Liens de la liste des animes"
+  },
   "autoSkip": {
     "message": "Saut automatique"
   },
@@ -84,6 +87,9 @@
   "disableNumpad": {
     "message": "Désactiver le pavé numérique"
   },
+  "doNotShow": {
+    "message": "Ne pas afficher"
+  },
   "editFastBackwardShortcut": {
     "message": "Éditer raccourci reculer"
   },
@@ -137,6 +143,9 @@
   },
   "hideUi": {
     "message": "Masquer UI"
+  },
+  "integrations": {
+    "message": "Intégrations"
   },
   "markAllNext": {
     "message": "Marquer tous les suivant"
@@ -203,6 +212,15 @@
   },
   "show": {
     "message": "Afficher"
+  },
+  "showOnSeries": {
+    "message": "Page de la série"
+  },
+  "showOnWatch": {
+    "message": "Page de veille"
+  },
+  "showOnSeriesAndWatch": {
+    "message": "Page des séries et de la veille"
   },
   "skip": {
     "message": "Sauter"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -20,6 +20,9 @@
   "addSpeedUpShortcut": {
     "message": "Adicionar atalho de aceleração"
   },
+  "animeListLinks": {
+    "message": "Links da lista de animes"
+  },
   "autoSkip": {
     "message": "Pular automático"
   },
@@ -84,6 +87,9 @@
   "disableNumpad": {
     "message": "Desabilitar o NumPad"
   },
+  "doNotShow": {
+    "message": "Não mostrar"
+  },
   "editFastBackwardShortcut": {
     "message": "Editar atalho de voltar"
   },
@@ -137,6 +143,9 @@
   },
   "hideUi": {
     "message": "Ocultar UI"
+  },
+  "integrations": {
+    "message": "Integrações"
   },
   "markAllNext": {
     "message": "Marcar todas os próximos"
@@ -203,6 +212,15 @@
   },
   "show": {
     "message": "Mostrar"
+  },
+  "showOnSeries": {
+    "message": "Serie página"
+  },
+  "showOnWatch": {
+    "message": "Mostrar página"
+  },
+  "showOnSeriesAndWatch": {
+    "message": "Página de series y relojes"
   },
   "skip": {
     "message": "Pular"

--- a/lib/background/background.js
+++ b/lib/background/background.js
@@ -2,7 +2,6 @@ chrome.runtime.onMessage.addListener(function ({ type, data }, { tab: { id: tabI
   switch (type) {
     case 'anilist':
       const { query } = data;
-      console.log(query);
       fetch('https://graphql.anilist.co', {
         method: 'POST',
         headers: {

--- a/lib/background/background.js
+++ b/lib/background/background.js
@@ -1,5 +1,20 @@
 chrome.runtime.onMessage.addListener(function ({ type, data }, { tab: { id: tabId } }, sendResponse) {
   switch (type) {
+    case 'anilist':
+      const { query } = data;
+      console.log(query);
+      fetch('https://graphql.anilist.co', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ query })
+      }).then((response) => response
+        .json()
+        .then((json) => sendResponse(json)
+        )
+      );
+      return true;
     case 'skippers':
       const {
         metadata: { id: mediaId, duration, episode_number, title },

--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -285,7 +285,6 @@ class SeriesAnimeListLinks {
     const seasonTitle = this.seasonNameContainer.textContent;
     animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
       this.container = new Renderer('div')
-        .setAttribute('style', 'margin-left: .75rem')
         .addClass('anime-list-link-container');
       if (chromeStorage.anilist_link.includes('series') && anilistButton) {
         this.container.appendChildren(anilistButton);

--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -2,11 +2,13 @@ class Series extends Empty {
   constructor() {
     super();
     this.markAsWatchedNotWatched = new MarkAsWatchedNotWatched();
-    this.animeListLinks = new SeriesAnimeListLinks();
+    if (chromeStorage.anilist_link.includes('series') || chromeStorage.myanimelist_link.includes('series')) {
+      this.animeListLinks = new SeriesAnimeListLinks();
+    }
 
     chrome.storage.onChanged.addListener((changes) => {
       if (changes.anilist_link || changes.myanimelist_link) {
-        this.animeListLinks.destroy();
+        this.animeListLinks?.destroy();
         this.animeListLinks = new SeriesAnimeListLinks();
       }
     });
@@ -15,7 +17,7 @@ class Series extends Empty {
   onDestroy() {
     super.onDestroy();
     this.markAsWatchedNotWatched.destroy();
-    this.animeListLinks.destroy();
+    this.animeListLinks?.destroy();
   }
 }
 
@@ -296,6 +298,6 @@ class SeriesAnimeListLinks {
   }
 
   destroy() {
-    this.container.remove();
+    this.container?.remove();
   }
 }

--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -2,11 +2,20 @@ class Series extends Empty {
   constructor() {
     super();
     this.markAsWatchedNotWatched = new MarkAsWatchedNotWatched();
+    this.animeListLinks = new SeriesAnimeListLinks();
+
+    chrome.storage.onChanged.addListener((changes) => {
+      if (changes.anilist_link || changes.myanimelist_link) {
+        this.animeListLinks.destroy();
+        this.animeListLinks = new SeriesAnimeListLinks();
+      }
+    });
   }
 
   onDestroy() {
     super.onDestroy();
     this.markAsWatchedNotWatched.destroy();
+    this.animeListLinks.destroy();
   }
 }
 
@@ -223,5 +232,70 @@ class MarkAsWatchedNotWatched {
         location.reload();
       }
     }, MarkAsWatchedNotWatched.REFRESH_TIMEOUT);
+  }
+}
+
+class SeriesAnimeListLinks {
+  container;
+
+  seasonsSelect;
+  seasonNameContainer;
+
+  constructor() {
+    this.seasonsSelect = document.querySelector('.seasons-select');
+    if (this.seasonsSelect) {
+      this.seasonNameContainer = this.seasonsSelect.querySelector('h4');
+      if (this.seasonNameContainer) {
+        this.createButtons()
+      } else {
+        new MutationObserver((_, observer) => {
+          this.seasonNameContainer = this.seasonsSelect.querySelector('h4');
+          if (!this.seasonNameContainer) return;
+          observer.disconnect();
+          this.createButtons();
+        }).observe(document.getElementById('content'), {
+          childList: true,
+          subtree: true,
+        })
+      }
+    } else {
+      new MutationObserver((_, observer) => {
+        this.seasonsSelect = document.querySelector('.seasons-select');
+        if (!this.seasonsSelect) return;
+        observer.disconnect();
+        new MutationObserver((_, observer) => {
+          this.seasonNameContainer = this.seasonsSelect.querySelector('h4');
+          if (!this.seasonNameContainer) return;
+          observer.disconnect();
+          this.createButtons();
+        }).observe(document.getElementById('content'), {
+          childList: true,
+          subtree: true,
+        })
+      }).observe(document.getElementById('content'), {
+        childList: true,
+        subtree: true,
+      })
+    }
+  }
+
+  createButtons() {
+    const seasonTitle = this.seasonNameContainer.textContent;
+    animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
+      this.container = new Renderer('div')
+        .setAttribute('style', 'margin-left: .75rem')
+        .addClass('anime-list-link-container');
+      if (chromeStorage.anilist_link.includes('series') && anilistButton) {
+        this.container.appendChildren(anilistButton);
+      }
+      if (chromeStorage.myanimelist_link.includes('series') && malButton) {
+        this.container.appendChildren(malButton);
+      }
+      this.seasonsSelect.append(this.container.getElement());
+    })
+  }
+
+  destroy() {
+    this.container.remove();
   }
 }

--- a/lib/content_scripts/website/pages/utils.css
+++ b/lib/content_scripts/website/pages/utils.css
@@ -1,7 +1,6 @@
 .anime-list-link-container {
     display: flex;
     align-items: center;
-    gap: .25rem;
 
     height: 100%;
     margin: auto 0 auto;
@@ -10,6 +9,10 @@
 .anime-list-link {
     width: 20px;
     height: 20px;
+}
+
+.anime-list-link:not(:last-of-type) {
+    margin-right: .25rem;
 }
 
 .anime-list-link > svg {

--- a/lib/content_scripts/website/pages/utils.css
+++ b/lib/content_scripts/website/pages/utils.css
@@ -1,0 +1,17 @@
+.anime-list-link-container {
+    display: flex;
+    align-items: center;
+    gap: .25rem;
+
+    height: 100%;
+    margin: auto 0 auto;
+}
+
+.anime-list-link {
+    width: 20px;
+    height: 20px;
+}
+
+.anime-list-link > svg {
+    border-radius: 2px;
+}

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -1,0 +1,66 @@
+function animeListButtons(title, callback) {
+  // remove the season number prefix ('S1:', 'S2:', ...)
+  title = title.replace(/^S\d+\s*[:-]\s*/, '');
+  // remove the dub or episode indicator that some season have ('(German Dub)', '(English Dub)', '(25+)', ...)
+  title = title.replace(/\([\w\s+-]+\)/, '');
+  title = title.trim();
+
+  chrome.runtime.sendMessage(chrome.runtime.id, {
+    type: 'anilist',
+    data: {
+      query: `query {
+            Media(search: "${title}", type: ANIME) {
+              id
+              idMal
+            }
+          }`
+    }
+  }, (response) => {
+    const anilistId = response.data.Media.id;
+    const malId = response.data.Media.idMal;
+
+    let anilistButton;
+    let malButton;
+    if (anilistId) {
+      anilistButton = new Renderer('a')
+        .addClass('anime-list-link')
+        .setAttribute('href', `https://anilist.co/anime/${anilistId}`)
+        .setAttribute('target', '_blank')
+        .appendChildren(
+          new SvgRenderer('svg')
+            .setAttribute('viewBox', '0 0 1024 1024')
+            .appendChildren(
+              new SvgRenderer('path')
+                .setAttribute('fill', '#1e2630')
+                .setAttribute('d', 'M0 0h1024v1024H0Z'),
+              new SvgRenderer('path')
+                .setAttribute('fill', '#02a9ff')
+                .setAttribute('d', 'M643.84 646.54V273.199c0-21.395-11.773-33.203-33.116-33.203h-72.865c-21.344 0-33.123 11.808-33.123 33.203v177.303c0 4.993 47.992 28.178 49.245 33.082 36.565 143.219 7.945 257.84-26.717 263.2 56.675 2.81 62.91 30.128 20.696 11.462 6.458-76.418 31.656-76.269 104.098-2.812.62.634 14.854 30.564 15.74 30.564h171.09c21.344 0 33.116-11.8 33.116-33.2v-73.048c0-21.396-11.772-33.203-33.116-33.203z'),
+              new SvgRenderer('path')
+                .setAttribute('fill', '#fefefe')
+                .setAttribute('d', 'M341.36 240 149.999 786h148.676l32.384-94.444h161.92L524.63 786h147.936L481.938 240Zm23.553 330.56 46.365-151.258 50.785 151.258z')
+            )
+        );
+    }
+    if (malId) {
+      malButton = new Renderer('a')
+        .addClass('anime-list-link')
+        .setAttribute('href', `https://myanimelist.net/anime/${malId}`)
+        .setAttribute('target', '_blank')
+        .appendChildren(
+          new SvgRenderer('svg')
+            .setAttribute('viewBox', '0 0 1024 1024')
+            .appendChildren(
+              new SvgRenderer('path')
+                .setAttribute('fill', '#2e51a2')
+                .setAttribute('d', 'M0 0h1024v1024H0Z'),
+              new SvgRenderer('path')
+                .setAttribute('fill', '#fff')
+                .setAttribute('d', 'M387.56 353.284v281.231l-70.21-.094v-174.1l-67.784 80.273-66.407-82.073-.673 176.464h-71.149V353.347h73.56l62.274 84.969 67.3-85zm288.07 69.083.83 211.522H597.5l-.265-95.862h-93.483c2.332 16.669 7.012 42.258 13.93 59.474 5.18 12.724 9.953 25.041 19.469 37.656l-56.922 37.562c-11.66-21.238-20.769-44.636-29.314-69.521a310.373 310.373 0 0 1-16.935-72.761c-2.833-25.042-3.24-49.113 3.569-73.857a130.481 130.481 0 0 1 38.767-62.306c10.455-9.782 25.041-16.7 36.733-22.944 11.69-6.245 24.806-8.812 36.967-11.989a247.284 247.284 0 0 1 39.769-6.104c13.287-1.142 36.967-2.206 79.82-.939l18.201 58.394H595.81c-19.798.266-29.314 0-44.777 6.98a74.655 74.655 0 0 0-42.664 64.169l88.913 1.095 1.267-60.428h77.097zm133.299-70.037v221.225l103.734 1.017-14.352 59.27h-160.5V351.281Z')
+            )
+        );
+    }
+
+    callback([anilistButton, malButton])
+  });
+}

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -5,20 +5,7 @@ function animeListButtons(title, callback) {
   title = title.replace(/\([\w\s+-]+\)/, '');
   title = title.trim();
 
-  chrome.runtime.sendMessage(chrome.runtime.id, {
-    type: 'anilist',
-    data: {
-      query: `query {
-            Media(search: "${title}", type: ANIME) {
-              id
-              idMal
-            }
-          }`
-    }
-  }, (response) => {
-    const anilistId = response.data.Media.id;
-    const malId = response.data.Media.idMal;
-
+  const callCallback = (anilistId, malId) => {
     let anilistButton;
     let malButton;
     if (anilistId) {
@@ -61,6 +48,32 @@ function animeListButtons(title, callback) {
         );
     }
 
-    callback([anilistButton, malButton])
-  });
+    callback([anilistButton, malButton]);
+  }
+
+  if (window.anilistCache && window.anilistCache[title]) {
+    callCallback(window.anilistCache[title].anilistId, window.anilistCache[title].malId);
+  } else {
+    chrome.runtime.sendMessage(chrome.runtime.id, {
+      type: 'anilist',
+      data: {
+        query: `query {
+            Media(search: "${title}", type: ANIME) {
+              id
+              idMal
+            }
+          }`
+      }
+    }, (response) => {
+      const anilistId = response.data.Media.id;
+      const malId = response.data.Media.idMal;
+      
+      if (!window.anilistCache) {
+        window.anilistCache = {};
+      }
+      window.anilistCache[title] = {anilistId: anilistId, malId: malId};
+
+      callCallback(anilistId, malId);
+    });
+  }
 }

--- a/lib/content_scripts/website/pages/watch/watch.js
+++ b/lib/content_scripts/website/pages/watch/watch.js
@@ -1,3 +1,65 @@
 class Watch extends Empty {
   static attributes = ['header_on_hover', 'player_mode', 'scrollbar'];
+
+  constructor() {
+    super();
+    this.animeListLinks = new WatchAnimeListLinks();
+
+    chrome.storage.onChanged.addListener((changes) => {
+      if (changes.anilist_link || changes.myanimelist_link) {
+        this.animeListLinks.destroy();
+        this.animeListLinks = new WatchAnimeListLinks();
+      }
+    });
+  }
+
+  onDestroy() {
+    super.onDestroy();
+    this.animeListLinks?.destroy();
+  }
+}
+
+class WatchAnimeListLinks {
+  currentMediaHeader;
+  container;
+
+  constructor() {
+    this.currentMediaHeader = document.querySelector('.current-media-header');
+    if (this.currentMediaHeader) {
+      this.createButtons()
+    } else {
+      new MutationObserver((_, observer) => {
+        this.currentMediaHeader = document.querySelector('.current-media-header');
+        if (!this.currentMediaHeader) return;
+        observer.disconnect();
+        this.createButtons();
+      }).observe(document.getElementById('content'), {
+        childList: true,
+        subtree: true,
+      })
+    }
+  }
+
+  createButtons() {
+    const seasonTitle = this.currentMediaHeader.querySelector('h4').textContent;
+    animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
+      this.container = new Renderer('div')
+        .addClass('anime-list-link-container');
+      if (chromeStorage.anilist_link.includes('watch') && anilistButton) {
+        this.container.appendChildren(anilistButton)
+      }
+      if (chromeStorage.myanimelist_link.includes('watch') && malButton) {
+        this.container.appendChildren(malButton)
+      }
+      this.container.appendChildren(this.currentMediaHeader.lastElementChild);
+      this.currentMediaHeader.append(this.container.getElement());
+    })
+  }
+
+  destroy() {
+    if (this.container) {
+      this.currentMediaHeader.append(this.container.getElement().lastElementChild);
+      this.container.remove();
+    }
+  }
 }

--- a/lib/content_scripts/website/pages/watch/watch.js
+++ b/lib/content_scripts/website/pages/watch/watch.js
@@ -3,11 +3,13 @@ class Watch extends Empty {
 
   constructor() {
     super();
-    this.animeListLinks = new WatchAnimeListLinks();
+    if (chromeStorage.anilist_link.includes('watch') || chromeStorage.myanimelist_link.includes('watch')) {
+      this.animeListLinks = new WatchAnimeListLinks();
+    }
 
     chrome.storage.onChanged.addListener((changes) => {
       if (changes.anilist_link || changes.myanimelist_link) {
-        this.animeListLinks.destroy();
+        this.animeListLinks?.destroy();
         this.animeListLinks = new WatchAnimeListLinks();
       }
     });

--- a/lib/popup/index.html
+++ b/lib/popup/index.html
@@ -50,6 +50,7 @@
   <script src='template/general.js'></script>
   <script src='template/player.js'></script>
   <script src='template/shortcuts.js'></script>
+  <script src='template/integrations.js'></script>
   <script src='template/settings.js'></script>
 </head>
 

--- a/lib/popup/template/integrations.js
+++ b/lib/popup/template/integrations.js
@@ -1,0 +1,73 @@
+core.main.integrations = {
+  type: 'folder',
+  label: 'integrations',
+  icon: new SvgRenderer('svg')
+    .setAttribute('viewBox', '0 0 512 512')
+    .appendChildren(
+      new SvgRenderer('path').setAttribute(
+        'd',
+        'M160 0c-17.7 0-32 14.3-32 32v96h64V32c0-17.7-14.3-32-32-32m192 0c-17.7 0-32 14.3-32 32v96h64V32c0-17.7-14.3-32-32-32M96 160c-17.7 0-32 14.3-32 32s14.3 32 32 32v32c0 77.4 55 142 128 156.8V480c0 17.7 14.3 32 32 32s32-14.3 32-32v-67.2C361 398 416 333.4 416 256v-32c17.7 0 32-14.3 32-32s-14.3-32-32-32z'
+      ),
+    ),
+
+  content: {
+    type: 'main',
+    label: 'integrations',
+
+    content: {
+      anime_lists: {
+        type: 'section',
+        label: 'animeListLinks',
+
+        content: {
+          anilist: {
+            type: 'select',
+            key: 'anilist_link',
+            label: 'AniList',
+            options: [
+              {
+                label: 'doNotShow',
+                value: '',
+              },
+              {
+                label: 'showOnSeries',
+                value: 'series',
+              },
+              {
+                label: 'showOnWatch',
+                value: 'watch',
+              },
+              {
+                label: 'showOnSeriesAndWatch',
+                value: 'series,watch'
+              }
+            ]
+          },
+          myanimelist: {
+            type: 'select',
+            key: 'myanimelist_link',
+            label: 'MyAnimeList',
+            options: [
+              {
+                label: 'doNotShow',
+                value: '',
+              },
+              {
+                label: 'showOnSeries',
+                value: 'series',
+              },
+              {
+                label: 'showOnWatch',
+                value: 'watch',
+              },
+              {
+                label: 'showOnSeriesAndWatch',
+                value: 'series,watch'
+              }
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/lib/shared/chromeStorage.js
+++ b/lib/shared/chromeStorage.js
@@ -21,6 +21,8 @@ const chromeStorage = new (class {
     skip_event_preview: 1,
     skip_event_recap: 1,
     theater_mode: true,
+    anilist_link: '',
+    myanimelist_link: ''
   };
   CHROME_STORAGE_NESTED = {
     shortcuts: {

--- a/manifest.json
+++ b/manifest.json
@@ -59,6 +59,7 @@
         "lib/content_scripts/website/api/api.js",
         "lib/content_scripts/website/action-menu/action-menu.js",
         "lib/content_scripts/website/pages/empty.js",
+        "lib/content_scripts/website/pages/utils.js",
         "lib/content_scripts/website/pages/series/series.js",
         "lib/content_scripts/website/pages/watch/watch.js",
         "lib/content_scripts/website/main.js"
@@ -67,6 +68,7 @@
         "lib/shared/theme-color.css",
         "lib/content_scripts/website/action-menu/action-menu.css",
         "lib/content_scripts/website/pages/watch/watch.css",
+        "lib/content_scripts/website/pages/utils.css",
         "lib/content_scripts/website/main.css"
       ],
       "run_at": "document_idle"


### PR DESCRIPTION
This adds the option to integrate AniList and MyAnimeList as additional buttons that will redirect to the series/season on the website. The links are gathered with the AniList graphql API by looking up the season name (the results of the api aren't always correct, but most of the time)

![image](https://github.com/ThomasTavernier/Improve-Crunchyroll/assets/63594396/db78bc0f-3e34-440d-ab93-6f48c7089e7a)
![image](https://github.com/ThomasTavernier/Improve-Crunchyroll/assets/63594396/be0ccb2d-4e07-4c07-9e28-c4e13636f76b)

(idk if the translations are correct, i've translated everything besides english with deepl)