### PR TITLE
feat(series): show next episode air date

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -165,6 +165,17 @@
   "maximizeOnDoubleClick": {
     "message": "Maximize on double-click"
   },
+  "nextEpisodeAirsAt": {
+    "message": "Next episode airs on $date$ at $time$",
+    "placeholders": {
+      "date": {
+        "content": "$1"
+      },
+      "time": {
+        "content": "$2"
+      }
+    }
+  },
   "none": {
     "message": "None"
   },
@@ -212,6 +223,9 @@
   },
   "show": {
     "message": "Show"
+  },
+  "showEpisodeAirDate": {
+    "message": "Show next episode air date"
   },
   "showOnSeries": {
     "message": "Series page"

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -165,6 +165,17 @@
   "maximizeOnDoubleClick": {
     "message": "Maximizar al hacer doble clic"
   },
+  "nextEpisodeAirsAt": {
+    "message": "El próximo episodio se emite en $date$ a $time$",
+    "placeholders": {
+      "date": {
+        "content": "$1"
+      },
+      "time": {
+        "content": "$2"
+      }
+    }
+  },
   "none": {
     "message": "Ninguno"
   },
@@ -212,6 +223,9 @@
   },
   "show": {
     "message": "Mostrar"
+  },
+  "showEpisodeAirDate": {
+    "message": "Fecha de emisión del próximo episodio"
   },
   "showOnSeries": {
     "message": "Serie página"

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -165,6 +165,17 @@
   "maximizeOnDoubleClick": {
     "message": "Agrandir lors d'un double-clic"
   },
+  "nextEpisodeAirsAt": {
+    "message": "Le prochain épisode sera diffusé le $date$ à $time$",
+    "placeholders": {
+      "date": {
+        "content": "$1"
+      },
+      "time": {
+        "content": "$2"
+      }
+    }
+  },
   "none": {
     "message": "Rien"
   },
@@ -212,6 +223,9 @@
   },
   "show": {
     "message": "Afficher"
+  },
+  "showEpisodeAirDate": {
+    "message": "Date de diffusion du prochain épisode"
   },
   "showOnSeries": {
     "message": "Page de la série"

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -165,6 +165,17 @@
   "maximizeOnDoubleClick": {
     "message": "Maximizar ao clicar duas vezes"
   },
+  "nextEpisodeAirsAt": {
+    "message": "Le prochain épisode sera diffusé le $date$ à $time$",
+    "placeholders": {
+      "date": {
+        "content": "$1"
+      },
+      "time": {
+        "content": "$2"
+      }
+    }
+  },
   "none": {
     "message": "Nenhum"
   },
@@ -212,6 +223,9 @@
   },
   "show": {
     "message": "Mostrar"
+  },
+  "showEpisodeAirDate": {
+    "message": "Data de exibição do próximo episódio"
   },
   "showOnSeries": {
     "message": "Serie página"

--- a/lib/content_scripts/website/pages/series/series.css
+++ b/lib/content_scripts/website/pages/series/series.css
@@ -1,0 +1,4 @@
+html[ic_page='series'] .next-air-date {
+    margin-top: .5rem;
+    text-decoration: underline #f47521;
+}

--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -5,11 +5,20 @@ class Series extends Empty {
     if (chromeStorage.anilist_link.includes('series') || chromeStorage.myanimelist_link.includes('series')) {
       this.animeListLinks = new SeriesAnimeListLinks();
     }
+    if (chromeStorage.episode_air_date_series) {
+      this.episodeAirDate = new EpisodeAirDate();
+    }
 
     chrome.storage.onChanged.addListener((changes) => {
       if (changes.anilist_link || changes.myanimelist_link) {
         this.animeListLinks?.destroy();
         this.animeListLinks = new SeriesAnimeListLinks();
+      }
+      if (changes.episode_air_date_series !== undefined) {
+        this.episodeAirDate?.destroy();
+        if (changes.episode_air_date_series.newValue) {
+          this.episodeAirDate = new EpisodeAirDate();
+        }
       }
     });
   }
@@ -18,6 +27,7 @@ class Series extends Empty {
     super.onDestroy();
     this.markAsWatchedNotWatched.destroy();
     this.animeListLinks?.destroy();
+    this.episodeAirDate?.destroy();
   }
 }
 
@@ -294,6 +304,90 @@ class SeriesAnimeListLinks {
       }
       this.seasonsSelect.append(this.container.getElement());
     })
+  }
+
+  destroy() {
+    this.container?.remove();
+  }
+}
+
+class EpisodeAirDate {
+  container;
+  actionButtons;
+
+  seriesId;
+
+  constructor() {
+    [this.seriesId] = location.pathname.match(/(?<=\/series\/)[^\/]*/) || [];
+
+    this.actionButtons = document.querySelector('.action-buttons');
+    if (!this.actionButtons) {
+      new MutationObserver((_, observer) => {
+        this.actionButtons = document.querySelector('.action-buttons');
+        if (!this.actionButtons) return;
+        observer.disconnect();
+        this.createElement();
+      }).observe(document.getElementById('content'), {
+        childList: true,
+        subtree: true,
+      })
+    } else {
+      this.createElement();
+    }
+  }
+
+  createElement() {
+    this.getAirDate((date) => {
+      if (!date) return;
+
+      this.container = new Renderer('p')
+        .addClass('next-air-date')
+        .setText(chrome.i18n.getMessage('nextEpisodeAirsAt', [Intl.DateTimeFormat(undefined, {
+          day: '2-digit',
+          weekday: 'long',
+          month: '2-digit'
+        }).format(date), Intl.DateTimeFormat(undefined, {
+          minute: '2-digit',
+          hour: '2-digit'
+        }).format(date)]))
+        .getElement();
+      this.actionButtons.append(this.container);
+    })
+  }
+
+  getAirDate(callback) {
+    if (!window.anilistCache) {
+      window.anilistCache = {};
+    }
+    if (window.anilistCache[this.seriesId] && window.anilistCache[this.seriesId].nextAiringDate > new Date(Date.now())) {
+      callback(window.anilistCache[this.seriesId].nextAiringDate);
+    } else {
+      chrome.runtime.sendMessage(chrome.runtime.id, {
+        type: 'anilist',
+        data: {
+          query: `query {
+            Media(search: "${document.location.pathname.split('/').slice(-1)[0]}", type: ANIME, status: RELEASING) {
+              nextAiringEpisode {
+                airingAt
+              }
+            }
+          }`
+        }
+      }, (response) => {
+        const airingAt = response.data.Media?.nextAiringEpisode?.airingAt;
+
+        if (!window.anilistCache[this.seriesId]) {
+          window.anilistCache[this.seriesId] = {};
+        }
+        if (airingAt) {
+          window.anilistCache[this.seriesId].nextAiringDate = new Date(airingAt * 1000);
+        } else {
+          window.anilistCache[this.seriesId].nextAiringDate = null;
+        }
+
+        callback(window.anilistCache[this.seriesId].nextAiringDate);
+      });
+    }
   }
 
   destroy() {

--- a/lib/popup/template/integrations.js
+++ b/lib/popup/template/integrations.js
@@ -15,6 +15,18 @@ core.main.integrations = {
     label: 'integrations',
 
     content: {
+      episode_air_date: {
+        type: 'section',
+        label: 'showEpisodeAirDate',
+
+        content: {
+          series: {
+            type: 'checkbox',
+            key: 'episode_air_date_series',
+            label: 'showOnSeries',
+          }
+        }
+      },
       anime_lists: {
         type: 'section',
         label: 'animeListLinks',

--- a/lib/shared/chromeStorage.js
+++ b/lib/shared/chromeStorage.js
@@ -22,7 +22,8 @@ const chromeStorage = new (class {
     skip_event_recap: 1,
     theater_mode: true,
     anilist_link: '',
-    myanimelist_link: ''
+    myanimelist_link: '',
+    episode_air_date_series: false,
   };
   CHROME_STORAGE_NESTED = {
     shortcuts: {

--- a/manifest.json
+++ b/manifest.json
@@ -67,6 +67,7 @@
       "css": [
         "lib/shared/theme-color.css",
         "lib/content_scripts/website/action-menu/action-menu.css",
+        "lib/content_scripts/website/pages/series/series.css",
         "lib/content_scripts/website/pages/watch/watch.css",
         "lib/content_scripts/website/pages/utils.css",
         "lib/content_scripts/website/main.css"


### PR DESCRIPTION
This adds an option to show the airing date of the next episode on the series page:
![image](https://github.com/ThomasTavernier/Improve-Crunchyroll/assets/63594396/15707aea-78fb-4f42-9522-d69996e14818)

The airing times are fetched via the AniList API, as Crunchyroll still isn't able to provide a good and reliable release calendar.
Sometimes the dates aren't correct, as AniList provides the japanese airing times which may differ from the times Crunchyroll has.

Shows that do not have an airing time/are completed do not show the label at all:
![image](https://github.com/ThomasTavernier/Improve-Crunchyroll/assets/63594396/0ef49616-142a-41f7-9bdd-ead79df69602)
