### PR TITLE
fix(general): listen to document head for callback invocations

### DIFF
--- a/lib/content_scripts/website/main.js
+++ b/lib/content_scripts/website/main.js
@@ -36,24 +36,12 @@ let locale;
     lastInstance = new clazz();
   };
 
-  const tryWatchTitle = () => {
-    const title = document.head.querySelector('title');
-    if (title) {
-      new MutationObserver(callback).observe(title, {
-        childList: true,
-      });
-      return true;
-    }
-    return false;
-  };
-
-  if (!tryWatchTitle()) {
-    new MutationObserver((_, observer) => {
-      if (tryWatchTitle()) {
-        observer.disconnect();
-      }
-    }).observe(document.head, {
-      childList: true,
-    });
-  }
+  let title = document.title;
+  new MutationObserver(() => {
+    if (document.title === title) return;
+    title = document.title;
+    callback();
+  }).observe(document.head, {
+    childList: true,
+  });
 })();


### PR DESCRIPTION
The customizations for the series / watch page aren't always applied, this affects Firefox (136.0.2; i've already encountered this in earlier FF versions) and Chrome (134.0.6998.88).
This PR changes the website callback listen target to `document.head` and compares the title manually in the observer function which eliminates the bug.

Also fixes the bug described in https://github.com/ThomasTavernier/Improve-Crunchyroll/issues/27#issuecomment-2694969853.