### PR TITLE
feat(player): hide last episode banner

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -141,6 +141,9 @@
   "hideSubtitles": {
     "message": "Untertitel ausblenden"
   },
+  "hideLastEpisodeBanner": {
+    "message": "Banner nach letzter Episode ausblenden"
+  },
   "hideUi": {
     "message": "Benutzeroberfläche ausblenden"
   },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -141,6 +141,9 @@
   "hideSubtitles": {
     "message": "Hide subtitles"
   },
+  "hideLastEpisodeBanner": {
+    "message": "Hide banner after last episode"
+  },
   "hideUi": {
     "message": "Hide UI"
   },

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -141,6 +141,9 @@
   "hideSubtitles": {
     "message": "Ocultar subtítulos"
   },
+  "hideLastEpisodeBanner": {
+    "message": "Ocultar banner después del último episodio"
+  },
   "hideUi": {
     "message": "Esconder UI"
   },

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -141,6 +141,9 @@
   "hideSubtitles": {
     "message": "Masquer les sous-titres"
   },
+  "hideLastEpisodeBanner": {
+    "message": "Cacher la bannière après le dernier épisode"
+  },
   "hideUi": {
     "message": "Masquer UI"
   },

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -141,6 +141,9 @@
   "hideSubtitles": {
     "message": "Ocultar legendas"
   },
+  "hideLastEpisodeBanner": {
+    "message": "Ocultar o banner após o último episódio"
+  },
   "hideUi": {
     "message": "Ocultar UI"
   },

--- a/lib/content_scripts/website/pages/watch/watch.js
+++ b/lib/content_scripts/website/pages/watch/watch.js
@@ -3,21 +3,68 @@ class Watch extends Empty {
 
   constructor() {
     super();
-    if (chromeStorage.anilist_link.includes('watch') || chromeStorage.myanimelist_link.includes('watch')) {
-      this.animeListLinks = new WatchAnimeListLinks();
-    }
 
-    chrome.storage.onChanged.addListener((changes) => {
-      if (changes.anilist_link || changes.myanimelist_link) {
-        this.animeListLinks?.destroy();
+    this.onStorageChange(chromeStorage);
+    chrome.storage.onChanged.addListener(this.onStorageChange);
+  }
+
+  onStorageChange(changes) {
+    if (changes.anilist_link !== undefined || changes.myanimelist_link !== undefined) {
+      this.animeListLinks?.destroy();
+      if (changes.anilist_link?.includes('watch') || changes.myanimelist_link?.includes('watch')) {
         this.animeListLinks = new WatchAnimeListLinks();
       }
-    });
+    }
+    if (changes.hide_last_episode_banner !== undefined) {
+      this.lastEpisodeBanner?.destroy();
+      if (changes.hide_last_episode_banner) {
+        this.lastEpisodeBanner = new WatchLastEpisodeBanner();
+      }
+    }
   }
 
   onDestroy() {
     super.onDestroy();
+    this.lastEpisodeBanner?.destroy();
     this.animeListLinks?.destroy();
+  }
+}
+
+class WatchLastEpisodeBanner {
+  watchEpisodeContainer;
+  observer;
+
+  constructor() {
+    this.watchEpisodeContainer = document.querySelector('.erc-watch-episode');
+    if (this.watchEpisodeContainer) {
+      this.createBannerObserver();
+    } else {
+      new MutationObserver((_, observer) => {
+        this.watchEpisodeContainer = document.querySelector('.erc-watch-episode');
+        if (!this.watchEpisodeContainer) return
+        observer.disconnect();
+        this.createBannerObserver();
+      }).observe(document.getElementById('content'), {
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+
+  createBannerObserver() {
+    this.observer = new MutationObserver(() => {
+      const banner = this.watchEpisodeContainer.querySelector('.erc-end-slate-recommendations-carousel');
+      if (banner) {
+        banner.querySelector('button[data-t="close-btn"]').click();
+      }
+    });
+    this.observer.observe(this.watchEpisodeContainer, {
+      childList: true,
+    })
+  }
+
+  destroy() {
+    this.observer?.disconnect();
   }
 }
 

--- a/lib/popup/template/player.js
+++ b/lib/popup/template/player.js
@@ -30,6 +30,11 @@ core.main.player = {
             key: 'hide_dim_screen',
             label: 'hideDimScreen',
           },
+          hide_last_episode_banner: {
+            type: 'checkbox',
+            key: 'hide_last_episode_banner',
+            label: 'hideLastEpisodeBanner',
+          },
           disable_numpad: {
             type: 'checkbox',
             key: 'disable_numpad',

--- a/lib/shared/chromeStorage.js
+++ b/lib/shared/chromeStorage.js
@@ -10,6 +10,7 @@ const chromeStorage = new (class {
     hide_dim_screen: false,
     hide_skip_button: false,
     hide_subtitles: false,
+    hide_last_episode_banner: false,
     hide_ui: '',
     open_header_menu_on_hover: false,
     player_mode: 2,


### PR DESCRIPTION
Crunchyroll added a banner popup that shows when finishing the last episode of a series. The banner consumes the whole page and interacting with the website isn't possible unless the close or start watching button is pressed. 
![image](https://github.com/user-attachments/assets/04fa351d-53a6-4697-8177-1d91724031fb)

This PR adds a option to hide the banner. This is done by pressing the close button as soon as the popup is added to the DOM.
When the banner is rendered, other parts of the website are also modified, e.g. a class is added to the body element which prevents scrolling. Pressing the close button cleans this up. Because of this I decided to go with javascript instead of css only.