### PR TITLE
fix(api): add device details to token request

### DIFF
--- a/lib/content_scripts/website/api/api.js
+++ b/lib/content_scripts/website/api/api.js
@@ -19,6 +19,17 @@ const API = new (class {
         return { apiDomain: location.origin, accountAuthClientId };
       });
     const get = () => {
+      let browser;
+      if (/Firefox/.test(navigator.userAgent)) browser = "Firefox";
+      else if (/Safari/.test(navigator.userAgent)) browser = "Safari";
+      else if (/Edge/.test(navigator.userAgent)) browser = "Edge";
+      else browser = "Chrome";
+
+      let os;
+      if (/Linux/.test(navigator.userAgent)) os = "Linux";
+      else if (/Mac/.test(navigator.userAgent)) os = "Mac";
+      else os = "Windows";
+
       Object.defineProperty(this, 'TOKEN', {
         value: cxApiParams.then(({ apiDomain, accountAuthClientId }) => {
           const fetchToken = (grant_type) =>
@@ -29,7 +40,11 @@ const API = new (class {
                 'Content-Type': 'application/x-www-form-urlencoded',
                 Authorization: `Basic ${window.btoa(`${accountAuthClientId}:`)}`,
               },
-              body: `grant_type=${grant_type}`,
+              body: new URLSearchParams({
+                device_id: /(?<=(?:^| )device_id=)[^;]+/.exec(document.cookie)[0],
+                device_type: `${browser} on ${os}`,
+                grant_type: grant_type
+              }),
             });
           return fetchToken('etp_rt_cookie')
             .then((response) => {


### PR DESCRIPTION
This PR fixes the token request. To request a token, the `device_type` and `device_id` of the requesting device must now be set along with the `grant_type`.
The device id is set when visiting the website and can be extracted from the cookies.
The device type must be created manually. It always has the form of `<browser> on <os>`. Browser and os are guessed from the user agent, the guessing tests the most popular browsers and operating systems and falls back to Chrome/Windows if something couldn't be guessed. I've also digged through the Crunchyroll javascript bundles to see how they do it but I couldn't find anything/didn't want to waste much time into it.

API requests like marking an episode as watched/unwatched need this fix to continue working.