### PR TITLE
feat(player): re-add resolution based quality

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -168,6 +168,9 @@
   "maximizeOnDoubleClick": {
     "message": "Maximieren bei Doppelklick"
   },
+  "resolutionBasedQuality": {
+    "message": "Quailitätsbasierte Auflösungseinstellung"
+  },
   "nextEpisodeAirsAt": {
     "message": "Nächste Episode wird am $date$ um $time$ ausgestrahlt",
     "placeholders": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -168,6 +168,9 @@
   "maximizeOnDoubleClick": {
     "message": "Maximize on double-click"
   },
+  "resolutionBasedQuality": {
+    "message": "Resolution based quality settings"
+  },
   "nextEpisodeAirsAt": {
     "message": "Next episode airs on $date$ at $time$",
     "placeholders": {

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -168,6 +168,9 @@
   "maximizeOnDoubleClick": {
     "message": "Maximizar al hacer doble clic"
   },
+  "resolutionBasedQuality": {
+    "message": "Configuración de calidad basada en la resolución"
+  },
   "nextEpisodeAirsAt": {
     "message": "El próximo episodio se emite en $date$ a $time$",
     "placeholders": {

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -168,6 +168,9 @@
   "maximizeOnDoubleClick": {
     "message": "Agrandir lors d'un double-clic"
   },
+  "resolutionBasedQuality": {
+    "message": "Paramètres de qualité basés sur la résolution"
+  },
   "nextEpisodeAirsAt": {
     "message": "Le prochain épisode sera diffusé le $date$ à $time$",
     "placeholders": {

--- a/_locales/pt_BR/messages.json
+++ b/_locales/pt_BR/messages.json
@@ -168,6 +168,9 @@
   "maximizeOnDoubleClick": {
     "message": "Maximizar ao clicar duas vezes"
   },
+  "resolutionBasedQuality": {
+    "message": "Configurações de qualidade baseadas em resolução"
+  },
   "nextEpisodeAirsAt": {
     "message": "Le prochain épisode sera diffusé le $date$ à $time$",
     "placeholders": {

--- a/lib/content_scripts/player/main.js
+++ b/lib/content_scripts/player/main.js
@@ -83,4 +83,4 @@ new MutationObserver((_, observer) => {
 
 // the quality settings must be overwritten immediately to take effect, if it's overwritten too late the player won't
 // recognize it anymore
-chrome.storage.local.get('resolution_based_quality', (result) => setQualitySettings(!result.resolution_based_quality));
+chrome.storage.local.get('resolution_based_quality', (result) => setQualitySettings(!(result.resolution_based_quality ?? true)));

--- a/lib/content_scripts/player/main.js
+++ b/lib/content_scripts/player/main.js
@@ -32,6 +32,11 @@ new MutationObserver((_, observer) => {
     doubleClickHandler();
     const icDivPlayerControls = createIcDiv();
     const icDivPlayerMode = createDivPlayerMode();
+    // the quality settings must be overwritten immediately to take effect, any asynchronous call like
+    // chromeStorage.LOADED.then is too slow
+    if (Object.getOwnPropertyDescriptor(chromeStorage, 'resolution_based_quality')?.get) {
+      setQualitySettings(!chromeStorage.resolution_based_quality);
+    }
     chromeStorage.LOADED.then(() => createFastForwardBackwardButtons(icDivPlayerControls));
     chrome.storage.onChanged.addListener((changes) => {
       if (changes.fast_backward_buttons || changes.fast_forward_buttons) {

--- a/lib/content_scripts/player/main.js
+++ b/lib/content_scripts/player/main.js
@@ -32,11 +32,6 @@ new MutationObserver((_, observer) => {
     doubleClickHandler();
     const icDivPlayerControls = createIcDiv();
     const icDivPlayerMode = createDivPlayerMode();
-    // the quality settings must be overwritten immediately to take effect, any asynchronous call like
-    // chromeStorage.LOADED.then is too slow
-    if (Object.getOwnPropertyDescriptor(chromeStorage, 'resolution_based_quality')?.get) {
-      setQualitySettings(!chromeStorage.resolution_based_quality);
-    }
     chromeStorage.LOADED.then(() => createFastForwardBackwardButtons(icDivPlayerControls));
     chrome.storage.onChanged.addListener((changes) => {
       if (changes.fast_backward_buttons || changes.fast_forward_buttons) {
@@ -85,3 +80,7 @@ new MutationObserver((_, observer) => {
 }).observe(document.documentElement, {
   childList: true,
 });
+
+// the quality settings must be overwritten immediately to take effect, if it's overwritten too late the player won't
+// recognize it anymore
+chrome.storage.local.get('resolution_based_quality', (result) => setQualitySettings(!result.resolution_based_quality));

--- a/lib/content_scripts/player/playback/playback.js
+++ b/lib/content_scripts/player/playback/playback.js
@@ -16,6 +16,16 @@ function setPlaybackRate(value = localStorage.getItem(icPlaybackRate) ?? 1, anim
   );
 }
 
+function setQualitySettings(enabled) {
+  const configDelta = window.localStorage.getItem('Vilos:ConfigDelta');
+  if (!configDelta) return;
+
+  const config = JSON.parse(configDelta);
+  config['qualitySettings'] = { enabled };
+
+  window.localStorage.setItem('Vilos:ConfigDelta', JSON.stringify(config));
+}
+
 function playbackHandler(player) {
   player.addEventListener('play', () => {
     document.documentElement.setAttribute('ic_playing', 'true');

--- a/lib/content_scripts/player/playback/playback.js
+++ b/lib/content_scripts/player/playback/playback.js
@@ -21,7 +21,7 @@ function setQualitySettings(enabled) {
   if (!configDelta) return;
 
   const config = JSON.parse(configDelta);
-  config['qualitySettings'] = { enabled };
+  config['qualitySettings'] = Object.assign(config['qualitySettings'] || {}, { enabled });
 
   window.localStorage.setItem('Vilos:ConfigDelta', JSON.stringify(config));
 }

--- a/lib/popup/template/player.js
+++ b/lib/popup/template/player.js
@@ -45,6 +45,11 @@ core.main.player = {
             key: 'maximize_on_double_click',
             label: 'maximizeOnDoubleClick',
           },
+          resolution_based_quality: {
+            type: 'checkbox',
+            key: 'resolution_based_quality',
+            label: 'resolutionBasedQuality',
+          },
           runnerThumbnail: {
             type: 'select',
             key: 'runnerThumbnail',

--- a/lib/shared/chromeStorage.js
+++ b/lib/shared/chromeStorage.js
@@ -4,6 +4,7 @@ const chromeStorage = new (class {
     auto_skip: false,
     disable_numpad: false,
     maximize_on_double_click: true,
+    resolution_based_quality: true,
     fast_backward_buttons: '30,10',
     fast_forward_buttons: '30,90',
     header_on_hover: true,


### PR DESCRIPTION
Crunchyroll recently rolled out a new quality selection:
<img width="360" height="325" alt="image" src="https://github.com/user-attachments/assets/33271e7e-90e8-4cc2-b456-470c1397df52" />

This is a terrible change imo, I've also heard complains from several different sources. Luckily it can be reverted by changing a setting in `localStorage`. This PR adds a option for this (activated by default).

When enabling/disabling the option in the extension and Crunchyroll is currently open in a tab, either a cache reload of the tab is required or closing and opening it again.

---

The config that is overwritten is fetched from Crunchyroll, so another approach would be to intercept the request (the endpoint is `https://beta-api.crunchyroll.com/config-delta/v1/apps/vilos-v2/config_delta`) in the background script and changing the value there. This might be more reliable (although I've never encountered the case that the old setting isn't reverted in my tests), but would required different implementations for mv2 and 3 (which is part of why I've opened #34).