### PR TITLE
fix(player): limit valid player fullscreen double click targets

### DIFF
--- a/lib/content_scripts/website/pages/watch/player/events/events.js
+++ b/lib/content_scripts/website/pages/watch/player/events/events.js
@@ -1,11 +1,28 @@
 class Events extends PlayerChild {
-  constructor() {
-    super();
-    const listener = () => {
+  initPlayer(player) {
+    super.initPlayer(player);
+    const playerClickPane = document.querySelector('[data-testid="player-controls-root"]');
+    const listener = (e) => {
       if (!chromeStorage.maximize_on_double_click) return;
+      // if the click target is not a direct child of the player click pane, traverse to the nearest visible element
+      // and check if this is a child of the click pane. some ui elements are nested, so this is necessary
+      if (e.target.parentNode != playerClickPane) {
+        let currentNode = e.target.parentNode;
+        while (currentNode) {
+          if (currentNode.checkVisibility && currentNode.checkVisibility()) break;
+          currentNode = currentNode.parentNode;
+        }
+
+        if (
+          currentNode.parentNode != playerClickPane &&
+          // cover edgecase: the space between the left and right bottom controls is seen as visible by js, although
+          // it's see-through
+          !(document.querySelector('[data-testid="bottom-left-controls-stack"]').parentNode == currentNode)
+        ) return;
+      }
       document.querySelector('[data-testid="fullscreen-button"]')?.click();
     };
-    window.addEventListener('dblclick', listener);
-    this.onDestroy(() => window.removeEventListener('dblclick', listener));
+    playerClickPane.addEventListener('dblclick', listener);
+    this.onDestroy(() => playerClickPane.removeEventListener('dblclick', listener));
   }
 }

--- a/lib/content_scripts/website/pages/watch/player/events/events.js
+++ b/lib/content_scripts/website/pages/watch/player/events/events.js
@@ -8,10 +8,7 @@ class Events extends PlayerChild {
       // and check if this is a child of the click pane. some ui elements are nested, so this is necessary
       if (e.target.parentNode != playerClickPane) {
         let currentNode = e.target.parentNode;
-        while (currentNode) {
-          if (currentNode.checkVisibility && currentNode.checkVisibility()) break;
-          currentNode = currentNode.parentNode;
-        }
+        while (!currentNode.checkVisibility()) currentNode = currentNode.parentNode;
 
         if (
           currentNode.parentNode != playerClickPane &&


### PR DESCRIPTION
Currently double clicking on anything on a watch page places the player in fullscreen (if the maximize on double click option is enabled). This PR limits the double click target to the player itself.
It now also respect control buttons and popups, for example previously, when clicking multiple times on a skip button or the time slider, this was recognized as a dblclick event and toggled the fullscreen mode.