### PR TITLE
feat(player): place playback speed slider correctly and update slider value

### DIFF
--- a/lib/content_scripts/website/pages/watch/player/playback-rate/playback-rate.js
+++ b/lib/content_scripts/website/pages/watch/player/playback-rate/playback-rate.js
@@ -12,8 +12,7 @@ class PlaybackRate extends PlayerChild {
 
   #handlePlaybackSettingsInsertion(playbackMenuParent, elements) {
     const observer = new MutationObserver(() => {
-      const playbackMenu = playbackMenuParent.querySelector('[data-testid="playback-speed-menu"]')?.firstChild
-        ?.firstChild;
+      const playbackMenu = playbackMenuParent.querySelector('[data-testid="playback-speed-menu"]')?.firstChild;
       if (playbackMenu) {
         const child = playbackMenu.firstElementChild.nextElementSibling;
         elements.forEach((element) => {
@@ -88,6 +87,7 @@ class PlaybackRate extends PlayerChild {
             .setAttribute('value', option.value)
             .addEventListener('input', ({ target: { value } }) => {
               option.value = value;
+              element.getElement().querySelector('.text').innerText = option.value + 'x';
             }),
         );
       }


### PR DESCRIPTION
Fixes the playback speed slider position and adds support for immediately updating the value left from the slider while sliding.

old:
<img width="235" height="304" alt="image" src="https://github.com/user-attachments/assets/35d3c347-b22e-473d-9e67-d41845c4ab7a" />

new:
<img width="235" height="304" alt="image" src="https://github.com/user-attachments/assets/92e3b6e7-35ad-4af1-95e3-2364189657b0" />
