### PR TITLE
[feat] Improve anime list season title linking

### DIFF
--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -329,7 +329,7 @@ class SeriesAnimeListLinks {
 
   createButtons() {
     const seasonTitle = this.seasonNameContainer.textContent;
-    animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
+    animeListButtons({ seasonTitle }, ([anilistButton, malButton]) => {
       this.container?.remove();
       this.container = new Renderer('div')
         .addClass('anime-list-link-container');

--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -287,6 +287,7 @@ class SeriesAnimeListLinks {
 
   seasonsSelect;
   seasonNameContainer;
+  seasonNameObserver;
 
   constructor() {
     this.seasonsSelect = document.querySelector('.seasons-select');
@@ -329,6 +330,7 @@ class SeriesAnimeListLinks {
   createButtons() {
     const seasonTitle = this.seasonNameContainer.textContent;
     animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
+      this.container?.remove();
       this.container = new Renderer('div')
         .addClass('anime-list-link-container');
       if (chromeStorage.anilist_link.includes('series') && anilistButton) {
@@ -338,11 +340,26 @@ class SeriesAnimeListLinks {
         this.container.appendChildren(malButton);
       }
       this.seasonsSelect.append(this.container.getElement());
+      this.watchSeasonNameChanges();
+    });
+  }
+
+  watchSeasonNameChanges() {
+    if (this.seasonNameObserver) {
+      this.seasonNameObserver.disconnect();
+    }
+    this.seasonNameObserver = new MutationObserver(() => {
+      this.createButtons();
+    });
+    this.seasonNameObserver.observe(this.seasonNameContainer, {
+      characterData: true,
+      subtree: true,
     });
   }
 
   destroy() {
     this.container?.remove();
+    this.seasonNameObserver?.disconnect();
   }
 }
 

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -7,7 +7,8 @@ function animeListButtons(title, callback) {
 
   // Check if the title is generic (e.g., 'Season 1', 'Season 2', etc.)
   // If so, use the series title from the page title instead to avoid incorrect linking
-  if (/^Season\s+\d+$/i.test(title)) {
+  const seasonPattern = /Season\s+(\d+)/i;
+  if (seasonPattern.test(title)) {
     let seriesTitle = null;
     
     // Pattern 1: Series page - "Watch {title} - Crunchyroll"
@@ -24,6 +25,15 @@ function animeListButtons(title, callback) {
     seriesTitle = seriesTitle.replace(/\([\w\s+-]+\)/, '').trim();
     
     if (seriesTitle) {
+      // If the series title doesn't already contain the current title, append it back to ensure correct linking
+      if (!seriesTitle.toLowerCase().includes(title.toLowerCase())) {
+        let seasonMatch = title.match(seasonPattern);
+        let seasonNumber = seasonMatch ? seasonMatch[1] : null;
+        if (seasonNumber) {
+          seriesTitle += ` Season ${seasonNumber}`;
+        }
+      }
+
       title = seriesTitle;
     }
   }

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -1,52 +1,77 @@
-function animeListButtons(seasonTitle, callback) {
-  let seriesTitle;
-  let fullTitle;
+function animeListButtons({ seriesTitle, seasonTitle }, callback) {
+  const cleanTitle = (title) => (title || '')
+    .replace(/^S\d+\s*[:-]\s*/, '')
+    .replace(/\([\w\s+-]+\)/, '')
+    .trim();
 
-  // Try to extract the series title from the page title using known patterns
-  // Pattern 1: Series page - "Watch {title} - Crunchyroll"
   const seriesMatch = document.title.match(/^Watch\s+(.+?)\s+-\s+Crunchyroll$/i);
-  if (seriesMatch) {
+  if (!seriesTitle && seriesMatch) {
     seriesTitle = seriesMatch[1];
-  } else {
-    // Pattern 2: Watch page - "{title} ({dub}) {ep title} - Watch on Crunchyroll"
-    seriesTitle = document.title.replace(/(\([\w\s+-]+\) .+)?\s+-\s+(Watch on )?Crunchyroll$/i, '').trim();
-    seriesTitle = seriesTitle.replace(/^Watch\s+/i, '');
+  } else if (!seriesTitle) {
+    seriesTitle = document.title
+      .replace(/(\([\w\s+-]+\) .+)?\s+-\s+(Watch on )?Crunchyroll$/i, '')
+      .replace(/^Watch\s+/i, '');
   }
 
-  // Clean up dub/episode indicators
-  seriesTitle = seriesTitle.replace(/\([\w\s+-]+\)/, '').trim();
+  seriesTitle = cleanTitle(seriesTitle);
+  seasonTitle = cleanTitle(seasonTitle);
 
-  // remove the season number prefix ('S1:', 'S2:', ...)
-  seasonTitle = seasonTitle.replace(/^S\d+\s*[:-]\s*/, '');
-  // remove the dub or episode indicator that some season have ('(German Dub)', '(English Dub)', '(25+)', ...)
-  seasonTitle = seasonTitle.replace(/\([\w\s+-]+\)/, '');
-  seasonTitle = seasonTitle.trim();
-
-  // Determine the full title to use for lookup based on the presence of series and season titles
-  if (!seriesTitle) {
-    fullTitle = seasonTitle;
-  } else if (!seasonTitle) {
-    fullTitle = seriesTitle;
-    // If the season title already contains the series title, use it as is to avoid redundancy (e.g., "One Piece Season 1")
-  } else if (seasonTitle.toLowerCase().includes(seriesTitle.toLowerCase())) {
-    fullTitle = seasonTitle;
-  } else {
-    // If the season title is generic and doesn't contain the series title, use the series title for lookup to ensure correct linking (e.g., "Season 1" => "One Piece")
-    let seasonMatch = seasonTitle.match(/Season\s+(\d+)/i);
-    if (seasonMatch) {
-      let seasonNumber = seasonMatch[1];
-      if (seasonNumber && seasonNumber !== '1') {
-        fullTitle = `${seriesTitle} Season ${seasonNumber}`;
-      } else {
-        fullTitle = seriesTitle;
-      }
-    } else if (/^OVAs?$/i.test(seasonTitle)) {
-      fullTitle = seriesTitle;
-      // In other cases, combine the series title and season title to ensure correct linking (e.g., "One Piece" + "Season 1" => "One Piece Season 1")
-    } else {
-      fullTitle = seriesTitle + ' ' + seasonTitle;
+  const addCandidate = (candidates, title) => {
+    if (title && !candidates.includes(title)) {
+      candidates.push(title);
     }
-  }
+  };
+  const getLookupCandidates = () => {
+    const candidates = [];
+    if (!seriesTitle) {
+      addCandidate(candidates, seasonTitle);
+    } else if (!seasonTitle) {
+      addCandidate(candidates, seriesTitle);
+    } else if (seasonTitle.toLowerCase().includes(seriesTitle.toLowerCase())) {
+      addCandidate(candidates, seasonTitle);
+      addCandidate(candidates, seriesTitle);
+    } else if (/^OVAs?$/i.test(seasonTitle)) {
+      addCandidate(candidates, seriesTitle);
+    } else {
+      const seasonMatch = seasonTitle.match(/Season\s+(\d+)/i);
+      if (seasonMatch) {
+        const seasonNumber = seasonMatch[1];
+        addCandidate(candidates, seasonNumber !== '1' ? `${seriesTitle} Season ${seasonNumber}` : seriesTitle);
+      } else {
+        addCandidate(candidates, `${seriesTitle} ${seasonTitle}`);
+      }
+      addCandidate(candidates, seriesTitle);
+    }
+    return candidates;
+  };
+
+  const lookupCandidates = getLookupCandidates();
+
+  const cacheKey = lookupCandidates[0] || seasonTitle || seriesTitle;
+
+  const readCachedResult = () => {
+    if (!window.anilistCache) return null;
+    const cachedTitle = lookupCandidates.find((title) => {
+      const cached = window.anilistCache[title];
+      return cached && (cached.anilistId || cached.malId);
+    });
+    if (cachedTitle) return window.anilistCache[cachedTitle];
+
+    const allCandidatesMissed = lookupCandidates.length > 0
+      && lookupCandidates.every((title) => window.anilistCache[title]);
+    return allCandidatesMissed ? window.anilistCache[cacheKey] || null : null;
+  };
+
+  const cacheResult = (title, anilistId, malId) => {
+    if (!title) return;
+    if (!window.anilistCache) window.anilistCache = {};
+    window.anilistCache[title] = { anilistId, malId };
+  };
+
+  const cacheMiss = () => {
+    lookupCandidates.forEach((title) => cacheResult(title, null, null));
+    cacheResult(cacheKey, null, null);
+  };
 
   const callCallback = (anilistId, malId) => {
     let anilistButton;
@@ -109,40 +134,29 @@ function animeListButtons(seasonTitle, callback) {
     });
   };
 
-  let title = fullTitle || seasonTitle;
-
-  // First check the cache to avoid unnecessary API calls
-  if (window.anilistCache && window.anilistCache[title]) {
-    callCallback(window.anilistCache[title].anilistId, window.anilistCache[title].malId);
+  const cached = readCachedResult();
+  if (cached) {
+    callCallback(cached.anilistId, cached.malId);
   } else {
-    // If not in cache, fetch from Anilist API using the full title first
-    fetchAnilist(title, (anilistId, malId) => {
-      if (anilistId || malId) {
-        // Found a match with the full title, cache it and return the buttons
-        if (!window.anilistCache) window.anilistCache = {};
-        window.anilistCache[title] = { anilistId, malId };
-        callCallback(anilistId, malId);
-      } else if (seriesTitle || seasonTitle) {
-        // If no match with the full title, try again with the simplified title (without season)
-        fetchAnilist(seriesTitle || seasonTitle, (a2, m2) => {
-          if (a2 || m2) {
-            // Found a match with the simplified title, cache it and return the buttons
-            if (!window.anilistCache) window.anilistCache = {};
-            window.anilistCache[title] = { anilistId: a2, malId: m2 };
-            callCallback(a2, m2);
-          } else {
-            // No match found even with the simplified title, cache the null result to avoid future lookups and return no buttons
-            if (!window.anilistCache) window.anilistCache = {};
-            window.anilistCache[title] = { anilistId: null, malId: null };
-            callCallback(null, null);
-          }
-        });
-      } else {
-        // No match found and no simplified title available, cache the null result to avoid future lookups and return no buttons
-        if (!window.anilistCache) window.anilistCache = {};
-        window.anilistCache[title] = { anilistId: null, malId: null };
+    const fetchCandidate = (index) => {
+      const title = lookupCandidates[index];
+      if (!title) {
+        cacheMiss();
         callCallback(null, null);
+        return;
       }
-    });
+
+      fetchAnilist(title, (anilistId, malId) => {
+        if (anilistId || malId) {
+          cacheResult(title, anilistId, malId);
+          cacheResult(cacheKey, anilistId, malId);
+          callCallback(anilistId, malId);
+        } else {
+          fetchCandidate(index + 1);
+        }
+      });
+    };
+
+    fetchCandidate(0);
   }
 }

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -10,7 +10,7 @@ function animeListButtons(title, callback) {
   // Check if the title is generic (e.g., 'Season 1', 'Season 2', etc.)
   // If so, use the series title from the page title instead to avoid incorrect linking
   const seasonPattern = /Season\s+(\d+)/i;
-  if (seasonPattern.test(title)) {
+  if (seasonPattern.test(title) || /^OVAs?$/i.test(title)) {
     let seriesTitle = null;
 
     // Pattern 1: Series page - "Watch {title} - Crunchyroll"

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -1,4 +1,6 @@
 function animeListButtons(title, callback) {
+  let simpleTitle = null;
+
   // remove the season number prefix ('S1:', 'S2:', ...)
   title = title.replace(/^S\d+\s*[:-]\s*/, '');
   // remove the dub or episode indicator that some season have ('(German Dub)', '(English Dub)', '(25+)', ...)
@@ -10,7 +12,7 @@ function animeListButtons(title, callback) {
   const seasonPattern = /Season\s+(\d+)/i;
   if (seasonPattern.test(title)) {
     let seriesTitle = null;
-    
+
     // Pattern 1: Series page - "Watch {title} - Crunchyroll"
     const seriesMatch = document.title.match(/^Watch\s+(.+?)\s+-\s+Crunchyroll$/i);
     if (seriesMatch) {
@@ -20,16 +22,18 @@ function animeListButtons(title, callback) {
       seriesTitle = document.title.replace(/(\([\w\s+-]+\) .+)?\s+-\s+(Watch on )?Crunchyroll$/i, '').trim();
       seriesTitle = seriesTitle.replace(/^Watch\s+/i, '');
     }
-    
+
     // Clean up dub/episode indicators
     seriesTitle = seriesTitle.replace(/\([\w\s+-]+\)/, '').trim();
-    
+
     if (seriesTitle) {
       // If the series title doesn't already contain the current title, append it back to ensure correct linking
       if (!seriesTitle.toLowerCase().includes(title.toLowerCase())) {
+        simpleTitle = seriesTitle;
+
         let seasonMatch = title.match(seasonPattern);
         let seasonNumber = seasonMatch ? seasonMatch[1] : null;
-        if (seasonNumber) {
+        if (seasonNumber && seasonNumber !== '1') {
           seriesTitle += ` Season ${seasonNumber}`;
         }
       }
@@ -84,29 +88,53 @@ function animeListButtons(title, callback) {
     callback([anilistButton, malButton]);
   };
 
-  if (window.anilistCache && window.anilistCache[title]) {
-    callCallback(window.anilistCache[title].anilistId, window.anilistCache[title].malId);
-  } else {
+  const fetchAnilist = (search, cb) => {
     chrome.runtime.sendMessage(chrome.runtime.id, {
       type: 'anilist',
       data: {
-        query: `query {
-            Media(search: "${title}", type: ANIME) {
-              id
-              idMal
-            }
-          }`,
+        query: `query { Media(search: ${JSON.stringify(search)}, type: ANIME) { id idMal } }`,
       },
     }, (response) => {
-      const anilistId = response.data.Media.id;
-      const malId = response.data.Media.idMal;
-
-      if (!window.anilistCache) {
-        window.anilistCache = {};
+      if (response && response.data && response.data.Media) {
+        cb(response.data.Media.id, response.data.Media.idMal);
+      } else {
+        cb(null, null);
       }
-      window.anilistCache[title] = { anilistId: anilistId, malId: malId };
+    });
+  };
 
-      callCallback(anilistId, malId);
+  // First check the cache to avoid unnecessary API calls
+  if (window.anilistCache && window.anilistCache[title]) {
+    callCallback(window.anilistCache[title].anilistId, window.anilistCache[title].malId);
+  } else {
+    // If not in cache, fetch from Anilist API using the full title first
+    fetchAnilist(title, (anilistId, malId) => {
+      if (anilistId || malId) {
+        // Found a match with the full title, cache it and return the buttons
+        if (!window.anilistCache) window.anilistCache = {};
+        window.anilistCache[title] = { anilistId, malId };
+        callCallback(anilistId, malId);
+      } else if (simpleTitle) {
+        // If no match with the full title, try again with the simplified title (without season)
+        fetchAnilist(simpleTitle, (a2, m2) => {
+          if (a2 || m2) {
+            // Found a match with the simplified title, cache it and return the buttons
+            if (!window.anilistCache) window.anilistCache = {};
+            window.anilistCache[title] = { anilistId: a2, malId: m2 };
+            callCallback(a2, m2);
+          } else {
+            // No match found even with the simplified title, cache the null result to avoid future lookups and return no buttons
+            if (!window.anilistCache) window.anilistCache = {};
+            window.anilistCache[title] = { anilistId: null, malId: null };
+            callCallback(null, null);
+          }
+        });
+      } else {
+        // No match found and no simplified title available, cache the null result to avoid future lookups and return no buttons
+        if (!window.anilistCache) window.anilistCache = {};
+        window.anilistCache[title] = { anilistId: null, malId: null };
+        callCallback(null, null);
+      }
     });
   }
 }

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -27,26 +27,25 @@ function animeListButtons(seasonTitle, callback) {
     fullTitle = seasonTitle;
   } else if (!seasonTitle) {
     fullTitle = seriesTitle;
-  // If the season title is generic and doesn't contain the series title, use the series title for lookup to ensure correct linking (e.g., "Season 1" => "One Piece")
-  } else if (/Season\s+(\d+)/i.test(seasonTitle) || /^OVAs?$/i.test(seasonTitle)) {
-    // If the series title doesn't already contain the current title, append it back to ensure correct linking
-    if (!seriesTitle.toLowerCase().includes(seasonTitle.toLowerCase())) {
-      let seasonMatch = seasonTitle.match(/Season\s+(\d+)/i);
-      let seasonNumber = seasonMatch ? seasonMatch[1] : null;
+    // If the season title already contains the series title, use it as is to avoid redundancy (e.g., "One Piece Season 1")
+  } else if (seasonTitle.toLowerCase().includes(seriesTitle.toLowerCase())) {
+    fullTitle = seasonTitle;
+  } else {
+    // If the season title is generic and doesn't contain the series title, use the series title for lookup to ensure correct linking (e.g., "Season 1" => "One Piece")
+    let seasonMatch = seasonTitle.match(/Season\s+(\d+)/i);
+    if (seasonMatch) {
+      let seasonNumber = seasonMatch[1];
       if (seasonNumber && seasonNumber !== '1') {
         fullTitle = `${seriesTitle} Season ${seasonNumber}`;
       } else {
         fullTitle = seriesTitle;
       }
-    } else {
+    } else if (/^OVAs?$/i.test(seasonTitle)) {
       fullTitle = seriesTitle;
+      // In other cases, combine the series title and season title to ensure correct linking (e.g., "One Piece" + "Season 1" => "One Piece Season 1")
+    } else {
+      fullTitle = seriesTitle + ' ' + seasonTitle;
     }
-  // If the season title already contains the series title, use it as is to avoid redundancy (e.g., "One Piece Season 1")
-  } else if (seasonTitle.toLowerCase().includes(seriesTitle.toLowerCase())) {
-    fullTitle = seasonTitle;
-  // In other cases, combine the series title and season title to ensure correct linking (e.g., "One Piece" + "Season 1" => "One Piece Season 1")
-  } else {
-    fullTitle = seriesTitle + ' ' + seasonTitle;
   }
 
   const callCallback = (anilistId, malId) => {

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -1,45 +1,52 @@
-function animeListButtons(title, callback) {
-  let simpleTitle = null;
+function animeListButtons(seasonTitle, callback) {
+  let seriesTitle;
+  let fullTitle;
+
+  // Try to extract the series title from the page title using known patterns
+  // Pattern 1: Series page - "Watch {title} - Crunchyroll"
+  const seriesMatch = document.title.match(/^Watch\s+(.+?)\s+-\s+Crunchyroll$/i);
+  if (seriesMatch) {
+    seriesTitle = seriesMatch[1];
+  } else {
+    // Pattern 2: Watch page - "{title} ({dub}) {ep title} - Watch on Crunchyroll"
+    seriesTitle = document.title.replace(/(\([\w\s+-]+\) .+)?\s+-\s+(Watch on )?Crunchyroll$/i, '').trim();
+    seriesTitle = seriesTitle.replace(/^Watch\s+/i, '');
+  }
+
+  // Clean up dub/episode indicators
+  seriesTitle = seriesTitle.replace(/\([\w\s+-]+\)/, '').trim();
 
   // remove the season number prefix ('S1:', 'S2:', ...)
-  title = title.replace(/^S\d+\s*[:-]\s*/, '');
+  seasonTitle = seasonTitle.replace(/^S\d+\s*[:-]\s*/, '');
   // remove the dub or episode indicator that some season have ('(German Dub)', '(English Dub)', '(25+)', ...)
-  title = title.replace(/\([\w\s+-]+\)/, '');
-  title = title.trim();
+  seasonTitle = seasonTitle.replace(/\([\w\s+-]+\)/, '');
+  seasonTitle = seasonTitle.trim();
 
-  // Check if the title is generic (e.g., 'Season 1', 'Season 2', etc.)
-  // If so, use the series title from the page title instead to avoid incorrect linking
-  const seasonPattern = /Season\s+(\d+)/i;
-  if (seasonPattern.test(title) || /^OVAs?$/i.test(title)) {
-    let seriesTitle = null;
-
-    // Pattern 1: Series page - "Watch {title} - Crunchyroll"
-    const seriesMatch = document.title.match(/^Watch\s+(.+?)\s+-\s+Crunchyroll$/i);
-    if (seriesMatch) {
-      seriesTitle = seriesMatch[1];
-    } else {
-      // Pattern 2: Watch page - "{title} ({dub}) {ep title} - Watch on Crunchyroll"
-      seriesTitle = document.title.replace(/(\([\w\s+-]+\) .+)?\s+-\s+(Watch on )?Crunchyroll$/i, '').trim();
-      seriesTitle = seriesTitle.replace(/^Watch\s+/i, '');
-    }
-
-    // Clean up dub/episode indicators
-    seriesTitle = seriesTitle.replace(/\([\w\s+-]+\)/, '').trim();
-
-    if (seriesTitle) {
-      // If the series title doesn't already contain the current title, append it back to ensure correct linking
-      if (!seriesTitle.toLowerCase().includes(title.toLowerCase())) {
-        simpleTitle = seriesTitle;
-
-        let seasonMatch = title.match(seasonPattern);
-        let seasonNumber = seasonMatch ? seasonMatch[1] : null;
-        if (seasonNumber && seasonNumber !== '1') {
-          seriesTitle += ` Season ${seasonNumber}`;
-        }
+  // Determine the full title to use for lookup based on the presence of series and season titles
+  if (!seriesTitle) {
+    fullTitle = seasonTitle;
+  } else if (!seasonTitle) {
+    fullTitle = seriesTitle;
+  // If the season title is generic and doesn't contain the series title, use the series title for lookup to ensure correct linking (e.g., "Season 1" => "One Piece")
+  } else if (/Season\s+(\d+)/i.test(seasonTitle) || /^OVAs?$/i.test(seasonTitle)) {
+    // If the series title doesn't already contain the current title, append it back to ensure correct linking
+    if (!seriesTitle.toLowerCase().includes(seasonTitle.toLowerCase())) {
+      let seasonMatch = seasonTitle.match(/Season\s+(\d+)/i);
+      let seasonNumber = seasonMatch ? seasonMatch[1] : null;
+      if (seasonNumber && seasonNumber !== '1') {
+        fullTitle = `${seriesTitle} Season ${seasonNumber}`;
+      } else {
+        fullTitle = seriesTitle;
       }
-
-      title = seriesTitle;
+    } else {
+      fullTitle = seriesTitle;
     }
+  // If the season title already contains the series title, use it as is to avoid redundancy (e.g., "One Piece Season 1")
+  } else if (seasonTitle.toLowerCase().includes(seriesTitle.toLowerCase())) {
+    fullTitle = seasonTitle;
+  // In other cases, combine the series title and season title to ensure correct linking (e.g., "One Piece" + "Season 1" => "One Piece Season 1")
+  } else {
+    fullTitle = seriesTitle + ' ' + seasonTitle;
   }
 
   const callCallback = (anilistId, malId) => {
@@ -103,6 +110,8 @@ function animeListButtons(title, callback) {
     });
   };
 
+  let title = fullTitle || seasonTitle;
+
   // First check the cache to avoid unnecessary API calls
   if (window.anilistCache && window.anilistCache[title]) {
     callCallback(window.anilistCache[title].anilistId, window.anilistCache[title].malId);
@@ -114,9 +123,9 @@ function animeListButtons(title, callback) {
         if (!window.anilistCache) window.anilistCache = {};
         window.anilistCache[title] = { anilistId, malId };
         callCallback(anilistId, malId);
-      } else if (simpleTitle) {
+      } else if (seriesTitle || seasonTitle) {
         // If no match with the full title, try again with the simplified title (without season)
-        fetchAnilist(simpleTitle, (a2, m2) => {
+        fetchAnilist(seriesTitle || seasonTitle, (a2, m2) => {
           if (a2 || m2) {
             // Found a match with the simplified title, cache it and return the buttons
             if (!window.anilistCache) window.anilistCache = {};

--- a/lib/content_scripts/website/pages/watch/watch.js
+++ b/lib/content_scripts/website/pages/watch/watch.js
@@ -111,8 +111,8 @@ class WatchAnimeListLinks {
   }
 
   createButtons() {
-    const seasonTitle = this.currentMediaHeader.querySelector('h4').textContent;
-    animeListButtons(seasonTitle, ([anilistButton, malButton]) => {
+    const seriesTitle = this.currentMediaHeader.querySelector('h4').textContent;
+    animeListButtons({ seriesTitle }, ([anilistButton, malButton]) => {
       this.container = new Renderer('div').addClass('anime-list-link-container');
       if (chromeStorage.anilist_link.includes('watch') && anilistButton) {
         this.container.appendChildren(anilistButton);

--- a/lib/content_scripts/website/pages/watch/watch.js
+++ b/lib/content_scripts/website/pages/watch/watch.js
@@ -112,7 +112,9 @@ class WatchAnimeListLinks {
 
   createButtons() {
     const seriesTitle = this.currentMediaHeader.querySelector('h4').textContent;
-    animeListButtons({ seriesTitle }, ([anilistButton, malButton]) => {
+    const seasonMatch = document.title.match(/Season\s+(\d+)/i);
+    const seasonTitle = seasonMatch ? `Season ${seasonMatch[1]}` : null;
+    animeListButtons({ seriesTitle, seasonTitle }, ([anilistButton, malButton]) => {
       this.container = new Renderer('div').addClass('anime-list-link-container');
       if (chromeStorage.anilist_link.includes('watch') && anilistButton) {
         this.container.appendChildren(anilistButton);


### PR DESCRIPTION
## Summary

- updates anime list title construction so generic Crunchyroll season labels resolve through the series title
- adds fallback lookup behavior when the full season-specific AniList query does not return a match
- refreshes series-page anime list buttons when the selected season name changes

## Impact

This should improve AniList/MyAnimeList link accuracy for generic season labels, OVAs, and season changes on series pages without requiring a page reload.

## Validation

- `git fetch origin --prune`
- `git diff --check origin/main..HEAD`
- `node --check lib/content_scripts/website/pages/utils.js`
- `node --check lib/content_scripts/website/pages/series/series.js`