### PR TITLE
fix(series): update anime list links when seasons change

### DIFF
--- a/lib/content_scripts/website/pages/series/series.js
+++ b/lib/content_scripts/website/pages/series/series.js
@@ -288,6 +288,8 @@ class SeriesAnimeListLinks {
   seasonsSelect;
   seasonNameContainer;
   seasonNameObserver;
+  seasonTitle;
+  requestId = 0;
 
   constructor() {
     this.seasonsSelect = document.querySelector('.seasons-select');
@@ -328,9 +330,20 @@ class SeriesAnimeListLinks {
   }
 
   createButtons() {
-    const seasonTitle = this.seasonNameContainer.textContent;
+    this.seasonNameContainer = this.seasonsSelect.querySelector('h4, span[class^=select-trigger__title]');
+    if (!this.seasonNameContainer) return;
+    if (!this.seasonNameObserver) this.watchSeasonNameChanges();
+
+    const seasonTitle = this.seasonNameContainer.textContent.trim();
+    if (!seasonTitle || seasonTitle === this.seasonTitle) return;
+
+    this.seasonTitle = seasonTitle;
+    const requestId = ++this.requestId;
+    this.container?.remove();
+
     animeListButtons({ seasonTitle }, ([anilistButton, malButton]) => {
-      this.container?.remove();
+      if (requestId !== this.requestId) return;
+
       this.container = new Renderer('div')
         .addClass('anime-list-link-container');
       if (chromeStorage.anilist_link.includes('series') && anilistButton) {
@@ -340,7 +353,6 @@ class SeriesAnimeListLinks {
         this.container.appendChildren(malButton);
       }
       this.seasonsSelect.append(this.container.getElement());
-      this.watchSeasonNameChanges();
     });
   }
 
@@ -351,13 +363,15 @@ class SeriesAnimeListLinks {
     this.seasonNameObserver = new MutationObserver(() => {
       this.createButtons();
     });
-    this.seasonNameObserver.observe(this.seasonNameContainer, {
+    this.seasonNameObserver.observe(this.seasonsSelect, {
+      childList: true,
       characterData: true,
       subtree: true,
     });
   }
 
   destroy() {
+    this.requestId++;
     this.container?.remove();
     this.seasonNameObserver?.disconnect();
   }

--- a/lib/content_scripts/website/pages/utils.js
+++ b/lib/content_scripts/website/pages/utils.js
@@ -47,30 +47,10 @@ function animeListButtons({ seriesTitle, seasonTitle }, callback) {
 
   const lookupCandidates = getLookupCandidates();
 
-  const cacheKey = lookupCandidates[0] || seasonTitle || seriesTitle;
-
-  const readCachedResult = () => {
-    if (!window.anilistCache) return null;
-    const cachedTitle = lookupCandidates.find((title) => {
-      const cached = window.anilistCache[title];
-      return cached && (cached.anilistId || cached.malId);
-    });
-    if (cachedTitle) return window.anilistCache[cachedTitle];
-
-    const allCandidatesMissed = lookupCandidates.length > 0
-      && lookupCandidates.every((title) => window.anilistCache[title]);
-    return allCandidatesMissed ? window.anilistCache[cacheKey] || null : null;
-  };
-
   const cacheResult = (title, anilistId, malId) => {
     if (!title) return;
     if (!window.anilistCache) window.anilistCache = {};
     window.anilistCache[title] = { anilistId, malId };
-  };
-
-  const cacheMiss = () => {
-    lookupCandidates.forEach((title) => cacheResult(title, null, null));
-    cacheResult(cacheKey, null, null);
   };
 
   const callCallback = (anilistId, malId) => {
@@ -134,29 +114,32 @@ function animeListButtons({ seriesTitle, seasonTitle }, callback) {
     });
   };
 
-  const cached = readCachedResult();
-  if (cached) {
-    callCallback(cached.anilistId, cached.malId);
-  } else {
-    const fetchCandidate = (index) => {
-      const title = lookupCandidates[index];
-      if (!title) {
-        cacheMiss();
-        callCallback(null, null);
-        return;
+  const fetchCandidate = (index) => {
+    const title = lookupCandidates[index];
+    if (!title) {
+      callCallback(null, null);
+      return;
+    }
+
+    const cached = window.anilistCache?.[title];
+    if (cached) {
+      if (cached.anilistId || cached.malId) {
+        callCallback(cached.anilistId, cached.malId);
+      } else {
+        fetchCandidate(index + 1);
       }
+      return;
+    }
 
-      fetchAnilist(title, (anilistId, malId) => {
-        if (anilistId || malId) {
-          cacheResult(title, anilistId, malId);
-          cacheResult(cacheKey, anilistId, malId);
-          callCallback(anilistId, malId);
-        } else {
-          fetchCandidate(index + 1);
-        }
-      });
-    };
+    fetchAnilist(title, (anilistId, malId) => {
+      cacheResult(title, anilistId, malId);
+      if (anilistId || malId) {
+        callCallback(anilistId, malId);
+      } else {
+        fetchCandidate(index + 1);
+      }
+    });
+  };
 
-    fetchCandidate(0);
-  }
+  fetchCandidate(0);
 }


### PR DESCRIPTION
## What broke

Crunchyroll does not reload the series page when you change seasons. It replaces the title element inside the season selector.

The extension watched that title element. After Crunchyroll replaced it, the observer kept watching a detached node and never saw later season changes. The AniList and MAL buttons therefore kept linking to the previous season.

The cache could make a wrong link stick. When a season-specific search missed and the generic series search succeeded, the code also saved that generic result under the season-specific key. Revisiting the season then returned the generic entry without trying the season search again.

Quick season changes exposed a separate race. An older lookup could finish after the current one and replace the correct buttons.

## What changed

The observer now watches .seasons-select, which Crunchyroll keeps in the page, and reads the current title after each change. A request counter discards results that belong to an older selection.

Each search candidate now has its own cache entry. Season searches still fall back to the generic series title, but the generic result is no longer saved as the season result.

## Tests

- JavaScript syntax checks pass for both changed files.
- The cache tests pass on the companion [test/series-anime-list-links](https://github.com/Alb11747/Improve-Crunchyroll/tree/test/series-anime-list-links) branch.